### PR TITLE
chore: Error handling when upload id I'd incorrect for Resumable upload

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -240,7 +240,6 @@ module Google
           # Initiating call
           response = client.delete(@upload_url, nil, request_header)
           handle_resumable_upload_http_response_codes(response)
-
           if !@upload_incomplete && (400..499).include?(response.status.to_i) && response.status.to_i != 404
             @close_io_on_finish = true
             true # method returns true if upload is successfully cancelled
@@ -248,7 +247,6 @@ module Google
             logger.debug { sprintf("Failed to cancel upload session. Response: #{response.status.to_i} - #{response.body}") }
             false
           end
-  
         end
 
         def handle_resumable_upload_http_response_codes(response)

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -149,9 +149,7 @@ module Google
         # Reinitiating resumable upload
         def reinitiate_resumable_upload(client)
           logger.debug { sprintf('Restarting resumable upload command to %s', url) }
-          unless check_resumable_upload client
-            return false
-          end
+          return false unless check_resumable_upload client
           upload_io.pos = @offset
         end
 

--- a/google-apis-core/spec/google/apis/core/service_spec.rb
+++ b/google-apis-core/spec/google/apis/core/service_spec.rb
@@ -287,6 +287,24 @@ RSpec.describe Google::Apis::Core::BaseService do
         expect(a_request(:put, upload_url)).to have_been_made
       end
     end
+    context 'Should return false if wrong upload id is provided' do
+      let(:upload_id) { 'wrong_id' }
+      let(:command) do
+        service.send(
+          :restart_resumable_upload,
+          bucket_name, file, upload_id,
+          options: { upload_chunk_size: 11}
+        )
+      end
+      before(:example) do
+        stub_request(:put, upload_url)
+          .to_return(status: 404)
+      end
+      it 'should return false' do
+        expect(command).to be_falsey
+      end
+    end
+
   end
 
   context 'delete resumable upload with upload_id' do
@@ -311,6 +329,24 @@ RSpec.describe Google::Apis::Core::BaseService do
       command
       expect(a_request(:delete, upload_url)).to have_been_made
       expect(command).to be_truthy
+    end
+
+    context 'Should return false if wrong upload id is provided' do
+      let(:upload_id) { 'wrong_id' }
+      let(:command) do
+      service.send(
+        :delete_resumable_upload,
+        bucket_name, upload_id,
+        options: { upload_chunk_size: 11}
+      )
+    end
+      before(:example) do
+        stub_request(:delete, upload_url)
+          .to_return(status: 404)
+      end
+      it 'should return false' do
+        expect(command).to be_falsey
+      end
     end
   end
 

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -161,6 +161,14 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       expect(a_request(:put, upload_url)
         .with(body: 'Hello world')).to have_been_made
     end
+
+    it 'should return false if wrong upload id is provided' do
+      stub_request(:put, upload_url)
+        .to_return(status: 404)
+      command.options.upload_chunk_size = 11
+      command.upload_id = "wrong_upload_id"
+      expect(command.execute(client)).to be_falsy
+    end
   end
 
   context('should not restart resumable upload if upload is completed') do
@@ -234,6 +242,15 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       command.execute(client)
       expect(a_request(:put, upload_url)
         .with(body: 'Hello world')).to have_not_been_made
+    end
+
+    it 'should return false if wrong upload id is provided' do
+      stub_request(:delete, upload_url)
+        .to_return(status: 404)
+      command.options.upload_chunk_size = 11
+      command.upload_id = "wrong_upload_id"
+      command.delete_upload = true
+      expect(command.execute(client)).to be_falsy
     end
   end
 


### PR DESCRIPTION
Updated code to  explicitly handle 404 (Not Found) responses, ensuring that operations correctly fail when an upload session ID is  invalid.

Error handling done for code implemented in  - https://github.com/googleapis/google-api-ruby-client/pull/21896, https://github.com/googleapis/google-api-ruby-client/pull/23376

Implementation linked with- https://github.com/googleapis/google-cloud-ruby/pull/30882