### PR TITLE
Enable CHecksum at object finalize

### DIFF
--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -136,7 +136,7 @@ module Google
           request_header[CONTENT_LENGTH_HEADER] = upload_io.size.to_s
           request_header[CONTENT_TYPE_HEADER] = JSON_CONTENT_TYPE
           request_header[UPLOAD_CONTENT_TYPE_HEADER] = upload_content_type unless upload_content_type.nil?
-          
+
           response = client.post(url.to_s, body, request_header) do |request|
             request.params.replace(request_query)
           end
@@ -193,7 +193,6 @@ module Google
           @upload_incomplete = false if response.status.to_i.eql? OK_STATUS
           @offset += current_chunk_size if @upload_incomplete
           success(result)
-          
         rescue => e
           logger.warn {
             "error occurred please use uploadId-#{response.headers['X-GUploader-UploadID']} to resume your upload , error==> #{e}"
@@ -251,7 +250,7 @@ module Google
 
         def handle_resumable_upload_http_response_codes(response)
           code = response.status.to_i
-          
+
           case code
           when 308
             if response.headers['Range']

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -177,7 +177,7 @@ module Google
           request_header[CONTENT_RANGE_HEADER] = get_content_range_header current_chunk_size
           request_header[CONTENT_LENGTH_HEADER] = current_chunk_size.to_s
           last_chunk= remaining_content_size <= current_chunk_size
-          hash_data= JSON.parse(body)
+          hash_data = body.to_s.empty? ? {} : JSON.parse(body)
 
           target_keys = ["crc32c", "md5Hash", "md5"]
           selected_keys = hash_data.slice(*target_keys)

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -136,9 +136,6 @@ module Google
           request_header[CONTENT_LENGTH_HEADER] = upload_io.size.to_s
           request_header[CONTENT_TYPE_HEADER] = JSON_CONTENT_TYPE
           request_header[UPLOAD_CONTENT_TYPE_HEADER] = upload_content_type unless upload_content_type.nil?
-          formatted_string = formatted_checksum_header
-          request_header['X-Goog-Hash'] = formatted_string unless formatted_string.empty?
-
           response = client.post(url.to_s, body, request_header) do |request|
             request.params.replace(request_query)
           end

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -32,7 +32,6 @@ module Google
         CONTENT_RANGE_HEADER = "Content-Range"
         RESUMABLE = "resumable"
         OK_STATUS = 200
-        UPLOAD_MISMATCH = "The uploaded data did not match the data from the server."
 
         # File name or IO containing the content to upload
         # @return [String, File, #read]
@@ -199,7 +198,6 @@ module Google
           @upload_incomplete = false if response.status.to_i.eql? OK_STATUS
           @offset += current_chunk_size if @upload_incomplete
           success(result)
-          end
           
         rescue => e
           logger.warn {

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -136,6 +136,7 @@ module Google
           request_header[CONTENT_LENGTH_HEADER] = upload_io.size.to_s
           request_header[CONTENT_TYPE_HEADER] = JSON_CONTENT_TYPE
           request_header[UPLOAD_CONTENT_TYPE_HEADER] = upload_content_type unless upload_content_type.nil?
+          
           response = client.post(url.to_s, body, request_header) do |request|
             request.params.replace(request_query)
           end
@@ -175,7 +176,7 @@ module Google
           request_header = header.dup
           request_header[CONTENT_RANGE_HEADER] = get_content_range_header current_chunk_size
           request_header[CONTENT_LENGTH_HEADER] = current_chunk_size.to_s
-          last_chunk= remaining_content_size <= current_chunk_size
+          last_chunk = remaining_content_size <= current_chunk_size
           formatted_string = formatted_checksum_header
           request_header['X-Goog-Hash'] = formatted_string if (last_chunk && !formatted_string.empty?)
   
@@ -185,7 +186,9 @@ module Google
             else
               StringIO.new(upload_io.read(current_chunk_size))
             end
+
           response = client.put(@upload_url, chunk_body, request_header)
+
           result = process_response(response.status.to_i, response.headers, response.body)
           @upload_incomplete = false if response.status.to_i.eql? OK_STATUS
           @offset += current_chunk_size if @upload_incomplete
@@ -248,6 +251,7 @@ module Google
 
         def handle_resumable_upload_http_response_codes(response)
           code = response.status.to_i
+          
           case code
           when 308
             if response.headers['Range']

--- a/google-apis-core/lib/google/apis/core/storage_upload.rb
+++ b/google-apis-core/lib/google/apis/core/storage_upload.rb
@@ -195,21 +195,10 @@ module Google
               StringIO.new(upload_io.read(current_chunk_size))
             end
           response = client.put(@upload_url, chunk_body, request_header)
-          # binding.pry
           result = process_response(response.status.to_i, response.headers, response.body)
-          
           @upload_incomplete = false if response.status.to_i.eql? OK_STATUS
           @offset += current_chunk_size if @upload_incomplete
-          if last_chunk
-            response_data = JSON.parse(response.body)
-            target_keys= selected_keys.keys
-            selected_keys_res= response_data.slice(*target_keys)
-
-            if selected_keys_res == selected_keys
-              success(result)
-            else
-              raise error UPLOAD_MISMATCH
-            end
+          success(result)
           end
           
         rescue => e

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'spec_helper'
+require_relative '../../../spec_helper'
 require 'google/apis/core/storage_upload'
 require 'google/apis/core/json_representation'
+require 'pry'
+require 'digest/crc32c'
 
 RSpec.describe Google::Apis::Core::StorageUploadCommand do
   include TestHelpers
@@ -117,7 +119,9 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
 
     before(:example) do
       stub_request(:put, 'https://www.googleapis.com/zoo/animals')
-        .with(headers: { 'Content-Range' => 'bytes 11-21/22' })
+        .with(headers: { 
+          'Content-Range' => 'bytes 11-21/22'
+        })
         .to_return(body: %(OK))
     end
 
@@ -307,4 +311,230 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
       expect { command.execute(client) }.to raise_error Google::Apis::ServerError
     end
   end
+  context 'when uploading with md5 checksum' do
+
+    let(:file) { StringIO.new(file_content) }
+    let(:md5_checksum) {"md5_checksum" }
+    let(:body_with_md5) { { "md5Hash" => md5_checksum }.to_json }
+
+    context 'with single shot upload' do
+      let(:file_content) { "Hello world" }
+
+      before(:example) do
+        command.body = body_with_md5
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
+          .to_return(body: %(OK))
+      end
+
+      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to have_been_made
+      end
+
+      it 'calls formatted_checksum_header and returns correct value' do
+        expect(command.formatted_checksum_header).to eq("md5=#{md5_checksum}")
+      end
+    end
+
+    context 'with chunked upload' do
+      let(:file_content) { "Hello world" * 2 }
+
+      before(:example) do
+        command.body = body_with_md5
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
+          .to_return(status: [308, 'Resume Incomplete'])
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 
+            'Content-Range' => 'bytes 11-21/22',
+            'X-Goog-Hash' => "md5=#{md5_checksum}"
+          })
+          .to_return(body: %(OK))
+      end
+
+      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to have_been_made
+      end
+
+      it 'includes md5 checksum in X-Goog-Hash header only in the last chunk' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        
+        # First chunk should NOT have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 0-10/22' && !req.headers.key?('X-Goog-Hash') }).to have_been_made
+        
+          # Last chunk should have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 11-21/22' && req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to have_been_made
+      end
+    end
+  end
+
+  context 'when uploading with crc32c checksum' do
+
+    let(:file) { StringIO.new(file_content) }
+    let(:crc32c_checksum) { "abc_checksum" }
+    let(:body_with_crc32c) { { "crc32c" => crc32c_checksum }.to_json }
+
+    context 'with single shot upload' do
+      let(:file_content) { "Hello world" }
+
+      before(:example) do
+        command.body = body_with_crc32c
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
+          .to_return(body: %(OK))
+      end
+
+      it 'includes crc32c checksum in X-Goog-Hash header during initiation' do
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to have_been_made
+      end
+
+      it 'calls formatted_checksum_header and returns correct value' do
+        expect(command.formatted_checksum_header).to eq("crc32c=#{crc32c_checksum}")
+      end
+    end
+
+    context 'with chunked upload' do
+      let(:file_content) { "Hello world" * 2 }
+
+      before(:example) do
+        command.body = body_with_crc32c
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
+          .to_return(status: [308, 'Resume Incomplete'])
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 
+            'Content-Range' => 'bytes 11-21/22',
+            'X-Goog-Hash' => "crc32c=#{crc32c_checksum}"
+          })
+          .to_return(body: %(OK))
+      end
+
+      it 'includes crc32c checksum in X-Goog-Hash header during initiation' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to have_been_made
+      end
+
+      it 'includes md5 checksum in X-Goog-Hash header only in the last chunk' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        
+        # First chunk should NOT have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 0-10/22' && !req.headers.key?('X-Goog-Hash') }).to have_been_made
+        
+          # Last chunk should have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 11-21/22' && req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to have_been_made
+      end
+
+    end
+  end
+
+  context 'when uploading with md5 and crc32c checksum' do
+     let(:file) { StringIO.new(file_content) }
+     let(:md5_checksum) { "md5_checksum"}
+     let(:crc32c_checksum) { "crc32c_checksum" }
+     let(:body_with_md5_crc32c) { { "md5Hash" => md5_checksum, "crc32c" => crc32c_checksum }.to_json }
+
+    context 'with single shot upload' do
+      let(:file_content) { "Hello world" }
+
+      before(:example) do
+        command.body = body_with_md5_crc32c
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
+          .to_return(body: %(OK))
+      end
+
+      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to have_been_made
+      end
+
+      it 'calls formatted_checksum_header and returns correct value' do
+        expect(command.formatted_checksum_header).to eq("crc32c=#{crc32c_checksum},md5=#{md5_checksum}")
+      end
+    end
+
+    context 'with chunked upload' do
+      let(:file_content) { "Hello world" * 2 }
+    
+      before(:example) do
+        command.body = body_with_md5_crc32c
+        allow(command).to receive(:formatted_checksum_header).and_call_original
+
+        stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
+          .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
+          .to_return(status: [308, 'Resume Incomplete'])
+        stub_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with(headers: { 
+            'Content-Range' => 'bytes 11-21/22',
+            'X-Goog-Hash' => "crc32c=#{crc32c_checksum},md5=#{md5_checksum}"
+          })
+          .to_return(body: %(OK))
+      end
+
+      it 'includes md5 and crc32c checksum in X-Goog-Hash header during initiation' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to have_been_made
+      end
+
+      it 'includes md5 and crc32c checksum in X-Goog-Hash header only in the last chunk' do
+        command.options.upload_chunk_size = 11
+        command.execute(client)
+        
+        # First chunk should NOT have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 0-10/22' && !req.headers.key?('X-Goog-Hash') }).to have_been_made
+        
+          # Last chunk should have the X-Goog-Hash header
+        expect(a_request(:put, 'https://www.googleapis.com/zoo/animals')
+          .with { |req| req.headers['Content-Range'] == 'bytes 11-21/22' && req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to have_been_made
+      end
+
+    end
+  end
+
 end

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../../spec_helper'
+require 'spec_helper'
 require 'google/apis/core/storage_upload'
 require 'google/apis/core/json_representation'
-require 'pry'
-require 'digest/crc32c'
 
 RSpec.describe Google::Apis::Core::StorageUploadCommand do
   include TestHelpers
@@ -325,17 +323,16 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         allow(command).to receive(:formatted_checksum_header).and_call_original
 
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
           .to_return(body: %(OK))
       end
 
-      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+      it 'should not include X-Goog-Hash header during initiation' do
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to_not have_been_made
       end
 
       it 'calls formatted_checksum_header and returns correct value' do
@@ -351,7 +348,6 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         allow(command).to receive(:formatted_checksum_header).and_call_original
 
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
@@ -364,11 +360,11 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
           .to_return(body: %(OK))
       end
 
-      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+      it 'should not include X-Goog-Hash header during initiation' do
         command.options.upload_chunk_size = 11
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "md5=#{md5_checksum}" }).to_not have_been_made
       end
 
       it 'includes md5 checksum in X-Goog-Hash header only in the last chunk' do
@@ -400,17 +396,16 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         allow(command).to receive(:formatted_checksum_header).and_call_original
 
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
           .to_return(body: %(OK))
       end
 
-      it 'includes crc32c checksum in X-Goog-Hash header during initiation' do
+      it 'should not include X-Goog-Hash header during initiation' do
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to_not have_been_made
       end
 
       it 'calls formatted_checksum_header and returns correct value' do
@@ -426,7 +421,6 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         allow(command).to receive(:formatted_checksum_header).and_call_original
 
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
@@ -439,11 +433,11 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
           .to_return(body: %(OK))
       end
 
-      it 'includes crc32c checksum in X-Goog-Hash header during initiation' do
+      it 'should not include X-Goog-Hash header during initiation' do
         command.options.upload_chunk_size = 11
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum}" }).to_not have_been_made
       end
 
       it 'includes md5 checksum in X-Goog-Hash header only in the last chunk' do
@@ -475,17 +469,16 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         command.body = body_with_md5_crc32c
         allow(command).to receive(:formatted_checksum_header).and_call_original
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
           .to_return(body: %(OK))
       end
 
-      it 'includes md5 checksum in X-Goog-Hash header during initiation' do
+      it 'should not include X-Goog-Hash header during initiation' do
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to_not have_been_made
       end
 
       it 'calls formatted_checksum_header and returns correct value' do
@@ -501,7 +494,6 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
         allow(command).to receive(:formatted_checksum_header).and_call_original
 
         stub_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }
           .to_return(headers: { 'Location' => 'https://www.googleapis.com/zoo/animals' }, body: %(OK))
         stub_request(:put, 'https://www.googleapis.com/zoo/animals')
           .with(headers: { 'Content-Range' => 'bytes 0-10/22' })
@@ -514,11 +506,11 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
           .to_return(body: %(OK))
       end
 
-      it 'includes md5 and crc32c checksum in X-Goog-Hash header during initiation' do
+      it 'should not includeX-Goog-Hash header during initiation' do
         command.options.upload_chunk_size = 11
         command.execute(client)
         expect(a_request(:post, 'https://www.googleapis.com/zoo/animals?uploadType=resumable')
-          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to have_been_made
+          .with { |req| req.headers['X-Goog-Hash'] == "crc32c=#{crc32c_checksum},md5=#{md5_checksum}" }).to_not have_been_made
       end
 
       it 'includes md5 and crc32c checksum in X-Goog-Hash header only in the last chunk' do

--- a/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
+++ b/google-apis-core/spec/google/apis/core/storage_upload_spec.rb
@@ -117,9 +117,7 @@ RSpec.describe Google::Apis::Core::StorageUploadCommand do
 
     before(:example) do
       stub_request(:put, 'https://www.googleapis.com/zoo/animals')
-        .with(headers: { 
-          'Content-Range' => 'bytes 11-21/22'
-        })
+        .with(headers: { 'Content-Range' => 'bytes 11-21/22'})
         .to_return(body: %(OK))
     end
 


### PR DESCRIPTION
This pull request introduces a mechanism to enable checksum validation during the finalization of object uploads. By including 'crc32c' and 'md5Hash' in the 'X-Goog-Hash' header for the last uploaded chunk, it ensures data integrity.

**Highlights:**
Checksum Validation: Implemented the addition of the 'X-Goog-Hash' header, containing 'crc32c' and 'md5Hash' values, specifically for the final chunk of an object upload to ensure data integrity.